### PR TITLE
feat(POR-7): Font loading (next/font) + atom components

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,36 +1,33 @@
-import type { Metadata } from 'next'
-import { Space_Grotesk, JetBrains_Mono } from 'next/font/google'
-import '@/styles/globals.css'
+import type { Metadata } from "next";
+import { Space_Grotesk, JetBrains_Mono } from "next/font/google";
+import "@/styles/globals.css";
 
 const spaceGrotesk = Space_Grotesk({
-  subsets: ['latin'],
-  weight: ['400', '500', '600'],
-  variable: '--font-space-grotesk',
-  display: 'swap',
-})
+  subsets: ["latin"],
+  weight: ["400", "500", "600"],
+  variable: "--font-space-grotesk",
+  display: "swap",
+});
 
 const jetbrainsMono = JetBrains_Mono({
-  subsets: ['latin'],
-  weight: ['400', '500'],
-  variable: '--font-jetbrains-mono',
-  display: 'swap',
-})
+  subsets: ["latin"],
+  weight: ["400", "500"],
+  variable: "--font-jetbrains-mono",
+  display: "swap",
+});
 
 export const metadata: Metadata = {
-  title: 'Christian Bega',
-  description: 'Portfolio of Christian Bega.',
-}
+  title: "Christian Bega",
+  description: "Portfolio of Christian Bega.",
+};
 
-export default function RootLayout({
-  children,
-}: {
-  children: React.ReactNode
-}) {
+export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" className={`${spaceGrotesk.variable} ${jetbrainsMono.variable}`}>
-      <body className="bg-base text-text-primary font-sans antialiased">
-        {children}
-      </body>
+      <head>
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tabler/icons-webfont@3.24.0/dist/tabler-icons.min.css" />
+      </head>
+      <body className="bg-base text-text-primary font-sans antialiased">{children}</body>
     </html>
-  )
+  );
 }

--- a/components/atoms/AccentMetric.tsx
+++ b/components/atoms/AccentMetric.tsx
@@ -1,0 +1,7 @@
+export function AccentMetric({ children }: { children: string }) {
+  return (
+    <span className="text-accent font-semibold shadow-accent-glow">
+      {children}
+    </span>
+  )
+}

--- a/components/atoms/DomainTag.tsx
+++ b/components/atoms/DomainTag.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from 'react'
+
+export function DomainTag({ children }: { children: ReactNode }) {
+  return (
+    <span className="font-mono text-tag tracking-[0.14em] text-accent uppercase">
+      {children}
+    </span>
+  )
+}

--- a/components/atoms/IconLink.tsx
+++ b/components/atoms/IconLink.tsx
@@ -1,0 +1,19 @@
+import type { ReactNode } from 'react'
+
+interface IconLinkProps {
+  href: string
+  icon: string
+  children: ReactNode
+}
+
+export function IconLink({ href, icon, children }: IconLinkProps) {
+  return (
+    <a
+      href={href}
+      className="flex items-center gap-[11px] text-text-secondary font-mono text-mono-md py-1.5 transition-colors hover:text-accent"
+    >
+      <i className={icon} aria-hidden="true" />
+      {children}
+    </a>
+  )
+}

--- a/components/atoms/SectionEyebrow.tsx
+++ b/components/atoms/SectionEyebrow.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from 'react'
+
+export function SectionEyebrow({ children }: { children: ReactNode }) {
+  return (
+    <h2 className="font-mono text-label font-medium tracking-[0.16em] text-text-faint uppercase">
+      {children}
+    </h2>
+  )
+}

--- a/components/atoms/TechChip.tsx
+++ b/components/atoms/TechChip.tsx
@@ -1,0 +1,4 @@
+export function TechChip({ children }: { children: string | string[] }) {
+  const label = Array.isArray(children) ? children.join(" · ") : children;
+  return <span className="font-mono text-mono-sm text-text-muted border border-border-card rounded-md px-2.5 py-1.5">{label}</span>;
+}


### PR DESCRIPTION
## What
Wires up self-hosted fonts and builds all 5 atom components that every
molecule and organism depends on.

## Changes
- `app/layout.tsx` — Space Grotesk + JetBrains Mono via next/font/google,
  CSS variables fed into Tailwind token system. Tabler Icons pinned to @3.24.0
- `components/atoms/SectionEyebrow` — h2 mono label for section headers
- `components/atoms/DomainTag` — accent mono domain tag (HEALTHCARE · EHR etc)
- `components/atoms/AccentMetric` — single glowing number, typed as string only
- `components/atoms/TechChip` — bordered mono pill, joins string arrays with · automatically
- `components/atoms/IconLink` — icon + label nav link with hover state

## Notes
- All atoms use Tailwind tokens only — no raw hex
- All named exports, all Server Components
- TechChip array join enforced in component, not at call site
- AccentMetric typed as `string` — enforces one metric per usage at the type level

## Verified
- `npm run build` produces `out/` clean
- 6 files changed, 1 commit