### PR TITLE
feat(POR-8): Starfield renderer + global atmosphere layer

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Space_Grotesk, JetBrains_Mono } from "next/font/google";
 import "@/styles/globals.css";
+import StarfieldRenderer from "@/components/organisms/StarfieldRenderer";
 
 const spaceGrotesk = Space_Grotesk({
   subsets: ["latin"],
@@ -27,7 +28,18 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <head>
         <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tabler/icons-webfont@3.24.0/dist/tabler-icons.min.css" />
       </head>
-      <body className="bg-base text-text-primary font-sans antialiased">{children}</body>
+      <body className="bg-base text-text-primary font-sans antialiased">
+        <StarfieldRenderer />
+        {/* Atmosphere — deep space gradient */}
+        <div
+          aria-hidden="true"
+          className="fixed inset-0 z-0 pointer-events-none"
+          style={{
+            background: "radial-gradient(135% 90% at 50% -12%, #1a1f4e 0%, #101a3c 26%, #0c1430 48%, #0a1026 68%, #080c1c 100%)",
+          }}
+        />
+        {children}
+      </body>
     </html>
   );
 }

--- a/components/organisms/StarfieldRenderer.tsx
+++ b/components/organisms/StarfieldRenderer.tsx
@@ -1,0 +1,11 @@
+"use client";
+import { useRef } from "react";
+import { useStarfield } from "@/lib/starfield";
+import { useReducedMotion } from "@/hooks/useReducedMotion";
+
+export default function StarfieldRenderer() {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const reduced = useReducedMotion();
+  useStarfield(canvasRef, !reduced);
+  return <canvas ref={canvasRef} aria-hidden="true" className="fixed inset-0 z-[1] pointer-events-none" />;
+}

--- a/hooks/useReducedMotion.ts
+++ b/hooks/useReducedMotion.ts
@@ -1,0 +1,1 @@
+export { useReducedMotion } from 'framer-motion'

--- a/lib/starfield/canvas.ts
+++ b/lib/starfield/canvas.ts
@@ -1,0 +1,177 @@
+import { RefObject, useEffect } from "react";
+
+// --- Types ---
+
+interface Star {
+  x: number;
+  y: number;
+  size: number;
+  opacity: number;
+  twinkle: boolean;
+  twinkleOffset: number;
+  twinkleSpeed: number; // each star pulses at its own rate
+}
+
+interface ShootingStar {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  life: number;
+  maxLife: number;
+}
+
+// --- Helpers ---
+
+function createStars(width: number, height: number, count: number): Star[] {
+  return Array.from({ length: count }, () => ({
+    x: Math.random() * width,
+    y: Math.random() * height,
+    size: Math.random() < 0.15 ? 3 : Math.random() < 0.5 ? 2 : 1,
+    opacity: Math.random() < 0.15 ? 0.7 : 0.3 + Math.random() * 0.4,
+    twinkle: Math.random() < 0.04,
+    twinkleOffset: Math.random() * Math.PI * 2,
+    twinkleSpeed: 0.3 + Math.random() * 0.4, // slow: 0.3–0.7 (was driven by global elapsed)
+  }));
+}
+
+function maybeSpawnShootingStar(shootingStars: ShootingStar[], width: number, height: number): ShootingStar[] {
+  if (Math.random() < 0.0002 && shootingStars.length === 0) {
+    shootingStars.push({
+      x: Math.random() * width * 0.6,
+      y: Math.random() * height * 0.3,
+      vx: 2.5 + Math.random() * 1.5, // slightly slower: 2.5–4
+      vy: 0.8 + Math.random() * 1.2,
+      life: 0,
+      maxLife: 90 + Math.random() * 40, // longer life
+    });
+  }
+  return shootingStars;
+}
+
+function drawStars(ctx: CanvasRenderingContext2D, stars: Star[], mouseX: number, mouseY: number, width: number, height: number, elapsed: number) {
+  stars.forEach((s) => {
+    const px = s.x + (mouseX - width / 2) * 0.008;
+    const py = s.y + (mouseY - height / 2) * 0.008;
+
+    let opacity = s.opacity;
+
+    if (s.twinkle) {
+      // Smooth sine wave at each star's own slow speed
+      // Result stays in range [baseOpacity * 0.5 ... baseOpacity * 1.5]
+      // smoothstep-style: use sin only, no abs() — that's what caused the LED flash
+      const wave = Math.sin(elapsed * s.twinkleSpeed + s.twinkleOffset);
+      // wave is -1..1; remap to 0.5..1.5 multiplier
+      const multiplier = 1 + wave * 0.5;
+      opacity = Math.min(s.opacity * multiplier, 1);
+    }
+
+    ctx.beginPath();
+    ctx.arc(px, py, s.size / 2, 0, Math.PI * 2);
+    ctx.fillStyle = `rgba(223, 226, 255, ${opacity})`;
+    ctx.fill();
+  });
+}
+
+function drawShootingStars(ctx: CanvasRenderingContext2D, shootingStars: ShootingStar[]): ShootingStar[] {
+  shootingStars.forEach((s) => {
+    const progress = s.life / s.maxLife;
+
+    // Smooth ease-in / ease-out alpha using smoothstep
+    const alpha =
+      progress < 0.15
+        ? (progress / 0.15) ** 2 // ease in
+        : 1 - ((progress - 0.15) / 0.85) ** 1.5; // ease out
+
+    // Longer trail — 30 frames back
+    const trailLength = 30;
+    const tailX = s.x - s.vx * trailLength;
+    const tailY = s.y - s.vy * trailLength;
+
+    const grad = ctx.createLinearGradient(tailX, tailY, s.x, s.y);
+    grad.addColorStop(0, `rgba(223, 226, 255, 0)`);
+    grad.addColorStop(0.3, `rgba(223, 226, 255, ${alpha * 0.15})`);
+    grad.addColorStop(0.7, `rgba(223, 226, 255, ${alpha * 0.5})`);
+    grad.addColorStop(1, `rgba(223, 226, 255, ${alpha * 0.95})`);
+
+    ctx.beginPath();
+    ctx.moveTo(tailX, tailY);
+    ctx.lineTo(s.x, s.y);
+    ctx.strokeStyle = grad;
+    ctx.lineWidth = 1.5;
+    ctx.stroke();
+
+    // Soft glow at head
+    const glow = ctx.createRadialGradient(s.x, s.y, 0, s.x, s.y, 3);
+    glow.addColorStop(0, `rgba(255, 255, 255, ${alpha})`);
+    glow.addColorStop(1, `rgba(223, 226, 255, 0)`);
+    ctx.beginPath();
+    ctx.arc(s.x, s.y, 3, 0, Math.PI * 2);
+    ctx.fillStyle = glow;
+    ctx.fill();
+
+    s.x += s.vx;
+    s.y += s.vy;
+    s.life++;
+  });
+
+  return shootingStars.filter((s) => s.life < s.maxLife);
+}
+
+// --- Hook ---
+
+export function useStarfield(canvasRef: RefObject<HTMLCanvasElement | null>, enabled: boolean) {
+  useEffect(() => {
+    if (!enabled) return;
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    const COUNT = 120;
+
+    const resize = () => {
+      canvas.width = window.innerWidth;
+      canvas.height = window.innerHeight;
+    };
+    resize();
+    window.addEventListener("resize", resize);
+
+    let stars = createStars(canvas.width, canvas.height, COUNT);
+    let shootingStars: ShootingStar[] = [];
+    let mouseX = 0;
+    let mouseY = 0;
+    let targetX = 0;
+    let targetY = 0;
+    let elapsed = 0;
+    let frame: number;
+
+    const onMouse = (e: MouseEvent) => {
+      targetX = e.clientX;
+      targetY = e.clientY;
+    };
+    window.addEventListener("mousemove", onMouse);
+
+    const draw = () => {
+      elapsed += 0.01; // slower tick — was 0.02
+      mouseX += (targetX - mouseX) * 0.05;
+      mouseY += (targetY - mouseY) * 0.05;
+
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+      drawStars(ctx, stars, mouseX, mouseY, canvas.width, canvas.height, elapsed);
+
+      shootingStars = maybeSpawnShootingStar(shootingStars, canvas.width, canvas.height);
+      shootingStars = drawShootingStars(ctx, shootingStars);
+
+      frame = requestAnimationFrame(draw);
+    };
+    draw();
+
+    return () => {
+      cancelAnimationFrame(frame);
+      window.removeEventListener("resize", resize);
+      window.removeEventListener("mousemove", onMouse);
+    };
+  }, [canvasRef, enabled]);
+}

--- a/lib/starfield/index.ts
+++ b/lib/starfield/index.ts
@@ -1,0 +1,1 @@
+export { useStarfield } from './canvas'

--- a/lib/starfield/webgl.ts
+++ b/lib/starfield/webgl.ts
@@ -1,0 +1,5 @@
+import { RefObject } from 'react'
+
+export function useStarfield(canvasRef: RefObject<HTMLCanvasElement | null>, enabled: boolean) {
+  // WebGL stub — swap in later by changing one import in index.ts
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@tabler/icons-webfont": "^3.34.0",
         "clsx": "^2.1.1",
+        "framer-motion": "^12.40.0",
         "next": "^15.3.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -3779,6 +3780,32 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.40.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.40.0.tgz",
+      "integrity": "sha512-uaBd3qC1v3KQqBEjwTUd183K6PbS+j0yR9w9VmEOLWA/tnUcSn8Xa3uck7t4dgpDoUss8xQTcj8W2L07lrnLFg==",
+      "dependencies": {
+        "motion-dom": "^12.40.0",
+        "motion-utils": "^12.39.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fs-extra": {
       "version": "11.2.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
@@ -5178,6 +5205,19 @@
       "engines": {
         "node": ">= 18"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.40.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.40.0.tgz",
+      "integrity": "sha512-HxU3ZaBwNPVQUBQf1xxgq+7JrPNZvjLVxgbpEZL7RrWJnsxOf0/OM+yrHG9ogLQ31Do/r57Oz2gQWPK+6q62mg==",
+      "dependencies": {
+        "motion-utils": "^12.39.0"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.39.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.39.0.tgz",
+      "integrity": "sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ=="
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@tabler/icons-webfont": "^3.34.0",
     "clsx": "^2.1.1",
+    "framer-motion": "^12.40.0",
     "next": "^15.3.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",


### PR DESCRIPTION
## What
Adds the global atmosphere layer and interactive starfield canvas that form
the visual foundation of the space theme.

## Changes
- `hooks/useReducedMotion.ts` — re-export from framer-motion, single import site
- `lib/starfield/canvas.ts` — modular canvas 2D implementation with:
  - 120 sparse stars with size variation
  - Smooth mouse parallax via lerp (0.05 factor)
  - ~4% of stars twinkle with individual speed/phase (pure sine, no flash)
  - Rare shooting stars (~every 30-60s) with 30-frame trail, radial glow head,
    smooth ease-in/out alpha
- `lib/starfield/webgl.ts` — stub for future WebGL upgrade
- `lib/starfield/index.ts` — swap boundary (change one import to upgrade)
- `components/organisms/StarfieldRenderer.tsx` — 'use client', canvas fixed
  inset-0 z-[1], gated on useReducedMotion
- `app/layout.tsx` — StarfieldRenderer + deep space radial gradient atmosphere

## Notes
- StarfieldRenderer is the only 'use client' component in the atmosphere layer
- Gradient div uses inline style (allowed exception per CLAUDE.md)
- All motion respects prefers-reduced-motion

## Verified
- npm run build produces out/ clean
- Stars render over gradient (z-index fix applied)
- Parallax, twinkle, and shooting star all verified visually