### PR TITLE
Feature/por 17

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,6 @@
 import HomeLayout from '@/layouts/HomeLayout'
 import PersonaColumn from '@/components/organisms/PersonaColumn'
+import MobileFooterBar from '@/components/organisms/MobileFooterBar'
 import { SectionEyebrow } from '@/components/atoms/SectionEyebrow'
 import ProjectCard from '@/components/molecules/ProjectCard'
 import { projects } from '@/data/projects'
@@ -44,29 +45,7 @@ export default function Home() {
       }
     />
 
-    {/* Mobile footer bar — lg:hidden */}
-    <div className="lg:hidden fixed bottom-0 left-0 right-0 z-50 flex items-center justify-between gap-3 px-5 py-3 border-t border-border-subtle"
-      style={{ background: 'rgba(10,13,23,0.85)', backdropFilter: 'blur(12px)' }}
-    >
-      <div className="flex items-center gap-4">
-        <a href="https://bit.ly/Cbega-GitHub" className="text-text-dim hover:text-accent transition-colors">
-          <i className="ti ti-brand-github text-[18px]" aria-hidden="true" />
-        </a>
-        <a href="https://bit.ly/Cbega-LinkedIn" className="text-text-dim hover:text-accent transition-colors">
-          <i className="ti ti-brand-linkedin text-[18px]" aria-hidden="true" />
-        </a>
-        <a href="/Christian_Bega_Resume_2026.pdf" className="text-text-dim hover:text-accent transition-colors">
-          <i className="ti ti-file-text text-[18px]" aria-hidden="true" />
-        </a>
-      </div>
-      <a
-        href="mailto:chrisb3ga@gmail.com"
-        className="flex items-center gap-2 bg-accent text-base text-sm font-medium px-4 py-2 rounded-lg transition-colors hover:opacity-90"
-      >
-        <i className="ti ti-mail text-[14px]" aria-hidden="true" />
-        Get in touch
-      </a>
-    </div>
+    <MobileFooterBar />
     </>
   )
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,10 +6,11 @@ import { projects } from '@/data/projects'
 
 export default function Home() {
   return (
+    <>
     <HomeLayout
       left={<PersonaColumn />}
       right={
-        <main className="relative py-[72px] px-[8px] pl-[52px] border-l border-border-subtle">
+        <main className="relative pt-4 pb-[72px] lg:py-[72px] px-5 lg:pl-[52px] lg:px-[8px] border-l border-border-subtle lg:pb-[84px]">
           {/* About */}
           <SectionEyebrow>About</SectionEyebrow>
           <p
@@ -42,5 +43,30 @@ export default function Home() {
         </main>
       }
     />
+
+    {/* Mobile footer bar — lg:hidden */}
+    <div className="lg:hidden fixed bottom-0 left-0 right-0 z-50 flex items-center justify-between gap-3 px-5 py-3 border-t border-border-subtle"
+      style={{ background: 'rgba(10,13,23,0.85)', backdropFilter: 'blur(12px)' }}
+    >
+      <div className="flex items-center gap-4">
+        <a href="https://bit.ly/Cbega-GitHub" className="text-text-dim hover:text-accent transition-colors">
+          <i className="ti ti-brand-github text-[18px]" aria-hidden="true" />
+        </a>
+        <a href="https://bit.ly/Cbega-LinkedIn" className="text-text-dim hover:text-accent transition-colors">
+          <i className="ti ti-brand-linkedin text-[18px]" aria-hidden="true" />
+        </a>
+        <a href="/Christian_Bega_Resume_2026.pdf" className="text-text-dim hover:text-accent transition-colors">
+          <i className="ti ti-file-text text-[18px]" aria-hidden="true" />
+        </a>
+      </div>
+      <a
+        href="mailto:chrisb3ga@gmail.com"
+        className="flex items-center gap-2 bg-accent text-base text-sm font-medium px-4 py-2 rounded-lg transition-colors hover:opacity-90"
+      >
+        <i className="ti ti-mail text-[14px]" aria-hidden="true" />
+        Get in touch
+      </a>
+    </div>
+    </>
   )
 }

--- a/components/organisms/MobileFooterBar.tsx
+++ b/components/organisms/MobileFooterBar.tsx
@@ -1,0 +1,27 @@
+export default function MobileFooterBar() {
+  return (
+    <div
+      className="lg:hidden fixed bottom-0 left-0 right-0 z-50 flex items-center justify-between gap-3 px-5 py-3 border-t border-border-subtle"
+      style={{ background: 'rgba(10,13,23,0.85)', backdropFilter: 'blur(12px)' }}
+    >
+      <div className="flex items-center gap-4">
+        <a href="https://bit.ly/Cbega-GitHub" className="text-text-dim hover:text-accent transition-colors">
+          <i className="ti ti-brand-github text-[18px]" aria-hidden="true" />
+        </a>
+        <a href="https://bit.ly/Cbega-LinkedIn" className="text-text-dim hover:text-accent transition-colors">
+          <i className="ti ti-brand-linkedin text-[18px]" aria-hidden="true" />
+        </a>
+        <a href="/Christian_Bega_Resume_2026.pdf" className="text-text-dim hover:text-accent transition-colors">
+          <i className="ti ti-file-text text-[18px]" aria-hidden="true" />
+        </a>
+      </div>
+      <a
+        href="mailto:chrisb3ga@gmail.com"
+        className="flex items-center gap-2 bg-accent text-base text-sm font-medium px-4 py-2 rounded-lg transition-colors hover:opacity-90"
+      >
+        <i className="ti ti-mail text-[14px]" aria-hidden="true" />
+        Get in touch
+      </a>
+    </div>
+  )
+}

--- a/components/organisms/PersonaColumn.tsx
+++ b/components/organisms/PersonaColumn.tsx
@@ -2,7 +2,7 @@ import { IconLink } from '@/components/atoms/IconLink'
 
 export default function PersonaColumn() {
   return (
-    <aside className="sticky top-0 h-screen overflow-visible border-r border-border-subtle flex flex-col justify-between pt-[72px] pb-[56px] pr-[44px] pl-[8px]">
+    <aside className="lg:sticky lg:top-0 lg:h-screen overflow-visible lg:border-r border-border-subtle flex flex-col justify-between pt-8 pb-6 px-5 lg:pt-[72px] lg:pb-[56px] lg:pr-[44px] lg:pl-[8px]">
       {/* Top block — identity */}
       <div className="relative z-10">
         <h1 className="text-h1 font-semibold text-text-primary">Christian Bega</h1>
@@ -17,7 +17,7 @@ export default function PersonaColumn() {
       </div>
 
       {/* Bottom block — links + CTA */}
-      <div className="relative z-10">
+      <div className="relative z-10 hidden lg:block">
         <nav className="flex flex-col">
           <IconLink icon="ti ti-brand-github" href="https://bit.ly/Cbega-GitHub">
             GitHub

--- a/layouts/HomeLayout.tsx
+++ b/layouts/HomeLayout.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from 'react'
 
 export default function HomeLayout({ left, right }: { left: ReactNode; right: ReactNode }) {
   return (
-    <div className="relative z-10 grid grid-cols-[37%_1fr] max-w-[1180px] mx-auto min-h-screen">
+    <div className="relative z-10 grid grid-cols-1 lg:grid-cols-[37%_1fr] max-w-[1180px] mx-auto min-h-screen">
       {left}
       {right}
     </div>


### PR DESCRIPTION
## POR-17 — Mobile responsive layout

### Changes
- `layouts/HomeLayout.tsx` — grid collapses to single column below lg:
  `grid-cols-1 lg:grid-cols-[37%_1fr]`
- `components/organisms/PersonaColumn.tsx` — sticky/h-screen scoped to
  `lg:` only; desktop links + CTA hidden on mobile (`hidden lg:block`)
- `app/page.tsx` — mobile sticky footer bar added (`lg:hidden`): GitHub,
  LinkedIn, Resume icons + "Get in touch" CTA fixed to bottom with
  backdrop blur; right column padding adjusted for mobile

### Breakpoints
- 375–767px: single column, compact persona header, sticky footer bar
- 768–1023px: single column, wider margins, same footer bar  
- 1024px+: two-column sticky layout unchanged, footer bar hidden