### PR TITLE
feat(POR-12): DetailLayout + HighlightBullet + ProjectBento + slug pages

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link'
 import HomeLayout from '@/layouts/HomeLayout'
 import PersonaColumn from '@/components/organisms/PersonaColumn'
 import MobileFooterBar from '@/components/organisms/MobileFooterBar'
@@ -34,13 +35,13 @@ export default function Home() {
           </div>
 
           {/* More projects link */}
-          <a
+          <Link
             href="/projects"
             className="inline-flex items-center gap-[8px] text-accent font-mono text-mono-md mt-[30px] py-[6px] transition-all hover:gap-[12px]"
           >
             <i className="ti ti-arrow-right" aria-hidden="true" />
             More projects, experiments &amp; home-lab notes
-          </a>
+          </Link>
         </main>
       }
     />

--- a/app/projects/[slug]/page.tsx
+++ b/app/projects/[slug]/page.tsx
@@ -1,0 +1,134 @@
+import { notFound } from 'next/navigation'
+import DetailLayout from '@/layouts/DetailLayout'
+import ProjectBento from '@/components/organisms/ProjectBento'
+import HighlightBullet from '@/components/molecules/HighlightBullet'
+import { AccentMetric } from '@/components/atoms/AccentMetric'
+import { DomainTag } from '@/components/atoms/DomainTag'
+import { SectionEyebrow } from '@/components/atoms/SectionEyebrow'
+import { TechChip } from '@/components/atoms/TechChip'
+import { projects } from '@/data/projects'
+
+export function generateStaticParams() {
+  return projects.map((project) => ({ slug: project.slug }))
+}
+
+export default async function ProjectDetailPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  const { slug } = await params
+  const project = projects.find((p) => p.slug === slug)
+  if (!project) notFound()
+
+  // Replace the {metric} placeholder in the one-liner with a glowing AccentMetric.
+  // When the project has no metric, the description renders as plain text.
+  const renderOneLiner = () => {
+    if (project.cardMetric === null) return project.cardDesc
+    const [before, after] = project.cardDesc.split('{metric}')
+    return (
+      <>
+        {before}
+        <AccentMetric>{project.cardMetric}</AccentMetric>
+        {after}
+      </>
+    )
+  }
+
+  return (
+    <DetailLayout>
+      <header className="mt-9 lg:mt-10">
+        <div className="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between lg:gap-10">
+          {/* Title block */}
+          <div className="max-w-[640px]">
+            <DomainTag>{project.tag}</DomainTag>
+            <h1 className="text-detail-h1 font-semibold text-text-primary mt-3">
+              {project.title}
+            </h1>
+            <p className="text-body text-text-muted leading-[1.7] mt-4">
+              {renderOneLiner()}
+            </p>
+          </div>
+
+          {/* Repo / site links */}
+          <div className="flex flex-wrap items-center gap-x-6 gap-y-2 font-mono text-mono-md text-text-dim shrink-0 lg:justify-end lg:text-right lg:mt-1">
+            {project.repo === 'private' && (
+              <span className="flex items-center gap-2">
+                <i className="ti ti-lock" aria-hidden="true" /> Private repo
+              </span>
+            )}
+            {project.repo === 'public' && project.repoUrl && (
+              <a
+                href={project.repoUrl}
+                className="flex items-center gap-2 transition-colors hover:text-accent"
+              >
+                <i className="ti ti-brand-github" aria-hidden="true" /> Source
+              </a>
+            )}
+            {project.siteUrl ? (
+              <a
+                href={project.siteUrl}
+                className="flex items-center gap-2 transition-colors hover:text-accent"
+              >
+                {project.siteLabel ?? project.siteUrl}
+                <i className="ti ti-arrow-up-right" aria-hidden="true" />
+              </a>
+            ) : project.siteLabel ? (
+              <span className="flex items-center gap-2">{project.siteLabel}</span>
+            ) : null}
+          </div>
+        </div>
+
+        {/* Tech */}
+        <div className="flex flex-wrap gap-2 mt-6">
+          {project.tech.map((t) => (
+            <TechChip key={t}>{t}</TechChip>
+          ))}
+        </div>
+      </header>
+
+      {/* Hero visual */}
+      <div className="mt-[68px] lg:mt-[72px]">
+        <ProjectBento slug={project.slug} />
+      </div>
+
+      {/* Summary */}
+      <section className="mt-[68px] lg:mt-[72px]">
+        <SectionEyebrow>Summary</SectionEyebrow>
+        <p className="text-body text-text-muted leading-[1.8] max-w-[680px] mt-4">
+          {project.summary}
+        </p>
+      </section>
+
+      {/* Role & Highlights */}
+      <section className="mt-[68px] lg:mt-[72px]">
+        <SectionEyebrow>Role &amp; Highlights</SectionEyebrow>
+        <div className="flex flex-col gap-[17px] mt-5">
+          {project.highlights.map((h) => (
+            <HighlightBullet key={h.text} icon={h.icon} text={h.text} metric={h.metric} />
+          ))}
+        </div>
+      </section>
+
+      {/* How it works (optional) */}
+      {project.howItWorks && (
+        <section className="mt-[68px] lg:mt-[72px]">
+          <SectionEyebrow>How it works</SectionEyebrow>
+          <p className="text-body text-text-muted leading-[1.8] max-w-[680px] mt-4">
+            {project.howItWorks}
+          </p>
+        </section>
+      )}
+
+      {/* What I learned (optional) */}
+      {project.whatILearned && (
+        <section className="mt-[68px] lg:mt-[72px]">
+          <SectionEyebrow>What I learned</SectionEyebrow>
+          <p className="text-body text-text-muted leading-[1.8] max-w-[680px] mt-4">
+            {project.whatILearned}
+          </p>
+        </section>
+      )}
+    </DetailLayout>
+  )
+}

--- a/components/molecules/HighlightBullet.tsx
+++ b/components/molecules/HighlightBullet.tsx
@@ -1,0 +1,33 @@
+import { AccentMetric } from '@/components/atoms/AccentMetric'
+
+interface HighlightBulletProps {
+  icon: string
+  text: string
+  metric?: string
+}
+
+export default function HighlightBullet({ icon, text, metric }: HighlightBulletProps) {
+  // Split the sentence on the {metric} placeholder and drop a glowing AccentMetric
+  // inline — same pattern as ProjectCard. With no metric, render the text as-is.
+  const renderText = () => {
+    if (!metric) return text
+    const [before, after] = text.split('{metric}')
+    return (
+      <>
+        {before}
+        <AccentMetric>{metric}</AccentMetric>
+        {after}
+      </>
+    )
+  }
+
+  return (
+    <div className="flex gap-3">
+      <i
+        className={`${icon} text-accent text-[16px] mt-[3px] shrink-0`}
+        aria-hidden="true"
+      />
+      <p className="text-body text-text-muted leading-[1.65]">{renderText()}</p>
+    </div>
+  )
+}

--- a/components/molecules/ProjectCard.tsx
+++ b/components/molecules/ProjectCard.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link'
 import { AccentMetric } from '@/components/atoms/AccentMetric'
 import { DomainTag } from '@/components/atoms/DomainTag'
 
@@ -33,7 +34,7 @@ export default function ProjectCard({
   }
 
   return (
-    <a
+    <Link
       href={`/projects/${slug}`}
       className="group grid grid-cols-[1fr_auto] py-[26px] px-[8px] border-t border-border-card transition-all duration-[180ms] hover:bg-[rgba(138,144,240,0.05)] hover:shadow-card-hover"
     >
@@ -53,6 +54,6 @@ export default function ProjectCard({
         className="ti ti-arrow-up-right text-text-faint text-[17px] mt-[6px]"
         aria-hidden="true"
       />
-    </a>
+    </Link>
   )
 }

--- a/components/organisms/ProjectBento.tsx
+++ b/components/organisms/ProjectBento.tsx
@@ -1,0 +1,76 @@
+interface ProjectBentoProps {
+  slug: string
+}
+
+type BentoTile = {
+  label: string
+  icon: string
+}
+
+type BentoLayout = {
+  // Large left tile spanning both rows on tablet/desktop.
+  hero: BentoTile & { subLabel: string }
+  topRight: BentoTile
+  bottomRight: BentoTile
+}
+
+// Placeholder tile config per project. Real screenshots/video swap in later;
+// for now every project renders patterned placeholder tiles.
+const LAYOUTS: Record<string, BentoLayout> = {
+  'alma-ehr': {
+    hero: { label: 'Demo video', subLabel: 'Product walkthrough', icon: 'ti ti-player-play' },
+    topRight: { label: 'Form builder', icon: 'ti ti-forms' },
+    bottomRight: { label: 'Practitioner dashboard', icon: 'ti ti-layout-dashboard' },
+  },
+  almadelic: {
+    hero: { label: 'Homepage', subLabel: 'Landing experience', icon: 'ti ti-browser' },
+    topRight: { label: 'Checkout', icon: 'ti ti-shopping-cart' },
+    bottomRight: { label: 'Mobile', icon: 'ti ti-device-mobile' },
+  },
+  'gardens-dispensary': {
+    hero: { label: 'Homepage', subLabel: 'Landing experience', icon: 'ti ti-browser' },
+    topRight: { label: 'Locations', icon: 'ti ti-map-pin' },
+    bottomRight: { label: 'Menu', icon: 'ti ti-list' },
+  },
+  'overland-baseball': {
+    hero: { label: 'Homepage', subLabel: 'Landing experience', icon: 'ti ti-browser' },
+    topRight: { label: 'Roster', icon: 'ti ti-users' },
+    bottomRight: { label: 'Admin dashboard', icon: 'ti ti-layout-dashboard' },
+  },
+}
+
+// Subtle repeating diagonal pattern over a faint solid fill — matches the
+// portfolio mockup tiles. Allowed inline-style exception for the gradient.
+const tileBackground =
+  'repeating-linear-gradient(135deg, rgba(255,255,255,0.022) 0 11px, rgba(255,255,255,0) 11px 22px), rgba(255,255,255,0.022)'
+
+export default function ProjectBento({ slug }: ProjectBentoProps) {
+  const layout = LAYOUTS[slug]
+
+  if (!layout) return null
+
+  return (
+    <div className="grid grid-cols-1 grid-rows-none gap-[10px] md:grid-cols-2 md:grid-rows-[200px_200px] lg:grid-cols-[1.5fr_1fr]">
+      {/* Hero — spans both rows on tablet/desktop, equal-height on mobile. */}
+      <div
+        className="flex min-h-[160px] flex-col items-center justify-center gap-2 rounded-[13px] border border-border-card text-text-faint md:row-span-2"
+        style={{ background: tileBackground }}
+      >
+        <i className={`${layout.hero.icon} text-[24px]`} aria-hidden="true" />
+        <span className="font-mono text-mono-sm text-text-faint">{layout.hero.label}</span>
+        <span className="mt-1 font-mono text-[10px] text-text-dim">{layout.hero.subLabel}</span>
+      </div>
+
+      {[layout.topRight, layout.bottomRight].map((tile) => (
+        <div
+          key={tile.label}
+          className="flex min-h-[160px] flex-col items-center justify-center gap-2 rounded-[13px] border border-border-card text-text-faint"
+          style={{ background: tileBackground }}
+        >
+          <i className={`${tile.icon} text-[20px]`} aria-hidden="true" />
+          <span className="font-mono text-mono-sm text-text-faint">{tile.label}</span>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/layouts/DetailLayout.tsx
+++ b/layouts/DetailLayout.tsx
@@ -1,0 +1,23 @@
+import type { ReactNode } from 'react'
+import Link from 'next/link'
+import MobileFooterBar from '@/components/organisms/MobileFooterBar'
+
+export default function DetailLayout({ children }: { children: ReactNode }) {
+  return (
+    // Single column, full width. The AtmosphereLayer/background lives in
+    // app/layout.tsx, so this only owns the foreground content. Extra bottom
+    // padding on mobile clears the fixed MobileFooterBar.
+    <main className="relative z-10 max-w-[880px] mx-auto px-5 lg:px-8 pt-10 lg:pt-[52px] pb-[80px] lg:pb-[110px]">
+      <Link
+        href="/"
+        className="inline-flex items-center gap-2 font-mono text-mono-md text-text-dim transition-colors hover:text-accent"
+      >
+        <span aria-hidden="true">←</span> Projects
+      </Link>
+
+      {children}
+
+      <MobileFooterBar />
+    </main>
+  )
+}


### PR DESCRIPTION
## POR-12 — Detail pages: DetailLayout + HighlightBullet + ProjectBento + slug pages

### New files
- `layouts/DetailLayout.tsx` — single column, max-w-[880px], back link,
  MobileFooterBar included, mobile-first padding
- `molecules/HighlightBullet.tsx` — icon + sentence, AccentMetric inline
  for glowing metric values via {metric} substitution
- `organisms/ProjectBento.tsx` — Option A bento layout: hero tile left
  spanning full height, two smaller tiles stacked right. Mobile: single
  column stack. Tablet: 2-col. Desktop: 1.5fr/1fr with row spans.
  Diagonal texture pattern per tile. Per-project tile config.
- `app/projects/[slug]/page.tsx` — generateStaticParams from projects.ts;
  renders all 4 detail pages with full section order per spec

### What's on each detail page
Back link → DomainTag → H1 → one-liner (with AccentMetric) → repo/site
links → TechChip row → ProjectBento → Summary → Role & Highlights →
optional How it works → optional What I learned

### Routes
- /projects/alma-ehr
- /projects/almadelic
- /projects/gardens-dispensary
- /projects/overland-baseball

### Mobile-first
- All layouts default mobile, desktop via lg: prefixes
- Bento: grid-cols-1 → md:grid-cols-2 → lg:grid-cols-[1.5fr_1fr]
- Padding: px-5 mobile → lg:px-8 desktop
- MobileFooterBar on all detail pages

### What this doesn't include
- Real screenshots/video — bento tiles are placeholders (POR pending
  once Christian provides assets)
- AccentMetric glow box fix → POR-18
- How it works diagram for AlmaEHR → content pending

### Test
- [ ] All 4 slugs resolve and npm run build succeeds
- [ ] Bento: single col at 375px, 2-col at 768px, hero-left at 1280px
- [ ] Optional sections only render when data field populated
- [ ] MobileFooterBar visible on mobile, hidden on desktop
- [ ] No raw hex in classNames
- [ ] All content from data/projects.ts — nothing hardcoded in JSX