### PR TITLE
feat(POR-18): AccentMetric: glow renders as visible box artifact, not…

### DIFF
--- a/components/atoms/AccentMetric.tsx
+++ b/components/atoms/AccentMetric.tsx
@@ -1,6 +1,6 @@
 export function AccentMetric({ children }: { children: string }) {
   return (
-    <span className="text-accent font-semibold shadow-accent-glow">
+    <span className="inline text-accent font-semibold [filter:drop-shadow(0_0_8px_rgba(138,144,240,0.6))]">
       {children}
     </span>
   )


### PR DESCRIPTION
## POR-18 — Fix AccentMetric glow box artifact

### Problem
AccentMetric rendered a visible rectangular box around the glow
instead of a clean inline text glow. The text-shadow was clipping
within the span's bounding box rather than bleeding into surrounding
text.

### Fix
- `components/atoms/AccentMetric.tsx` — replaced `shadow-accent-glow`
  (box-shadow/text-shadow) with `[filter:drop-shadow(0_0_8px_rgba(138,144,240,0.6))]`
  Tailwind arbitrary value; confirmed `display: inline` (not inline-block)

### Why it works
CSS `filter: drop-shadow()` applies outside the element's stacking
context — it bleeds naturally into surrounding text. `text-shadow`
and `box-shadow` are clipped to the element's paint box, producing
the visible rectangle.

### Test
- [ ] ~75%, ~3.5%, 2,000+ on home page cards — no visible box
- [ ] Same metrics on detail page Role & Highlights bullets
- [ ] Glow still renders in accent violet (#8a90f0)
- [ ] Looks correct on mobile and desktop