### PR TITLE
feat(POR-21): Motion pass — Framer Motion: glow breathe, card hover, …

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,7 +2,6 @@ import type { Metadata } from "next";
 import { Space_Grotesk, JetBrains_Mono } from "next/font/google";
 import "@/styles/globals.css";
 import StarfieldRenderer from "@/components/organisms/StarfieldRenderer";
-import NebulaLayer from "@/components/organisms/NebulaLayer";
 
 const spaceGrotesk = Space_Grotesk({
   subsets: ["latin"],
@@ -39,8 +38,6 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             background: "radial-gradient(135% 90% at 50% -12%, #1a1f4e 0%, #101a3c 26%, #0c1430 48%, #0a1026 68%, #080c1c 100%)",
           }}
         />
-        {/* Nebula haze — sits above the atmosphere gradient, below the stars */}
-        <NebulaLayer />
         {children}
       </body>
     </html>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,49 +1,14 @@
-import Link from 'next/link'
 import HomeLayout from '@/layouts/HomeLayout'
 import PersonaColumn from '@/components/organisms/PersonaColumn'
 import MobileFooterBar from '@/components/organisms/MobileFooterBar'
-import { SectionEyebrow } from '@/components/atoms/SectionEyebrow'
-import ProjectCard from '@/components/molecules/ProjectCard'
-import { projects } from '@/data/projects'
+import RightColumnContent from '@/components/organisms/RightColumnContent'
 
 export default function Home() {
   return (
     <>
     <HomeLayout
       left={<PersonaColumn />}
-      right={
-        <main className="relative pt-4 pb-[72px] lg:py-[72px] px-5 lg:pl-[52px] lg:px-[8px] border-l border-border-subtle lg:pb-[84px]">
-          {/* About */}
-          <SectionEyebrow>About</SectionEyebrow>
-          <p
-            className="text-body text-text-muted leading-[1.85] max-w-[580px] mt-4 mb-[56px]"
-            style={{ textWrap: 'pretty' }}
-          >
-            Full-stack developer in Denver with three years building production
-            software for a telehealth startup, where I grew from entry-level into
-            the lead role. Most of my work lives on the backend and in
-            infrastructure — a custom FHIR-based EHR, serverless APIs, CI/CD,
-            and integrations across Stripe, CRM, and healthcare systems.
-          </p>
-
-          {/* Featured Projects */}
-          <SectionEyebrow>Featured Projects</SectionEyebrow>
-          <div className="flex flex-col mt-1 border-b border-border-card">
-            {projects.map((project) => (
-              <ProjectCard key={project.slug} {...project} />
-            ))}
-          </div>
-
-          {/* More projects link */}
-          <Link
-            href="/projects"
-            className="inline-flex items-center gap-[8px] text-accent font-mono text-mono-md mt-[30px] py-[6px] transition-all hover:gap-[12px]"
-          >
-            <i className="ti ti-arrow-right" aria-hidden="true" />
-            More projects, experiments &amp; home-lab notes
-          </Link>
-        </main>
-      }
+      right={<RightColumnContent />}
     />
 
     <MobileFooterBar />

--- a/components/molecules/ProjectCard.tsx
+++ b/components/molecules/ProjectCard.tsx
@@ -1,6 +1,12 @@
+'use client'
+
 import Link from 'next/link'
+import { motion } from 'framer-motion'
 import { AccentMetric } from '@/components/atoms/AccentMetric'
 import { DomainTag } from '@/components/atoms/DomainTag'
+import { useReducedMotion } from '@/hooks/useReducedMotion'
+
+const MotionLink = motion.create(Link)
 
 interface ProjectCardProps {
   slug: string
@@ -33,11 +39,12 @@ export default function ProjectCard({
     )
   }
 
-  return (
-    <Link
-      href={`/projects/${slug}`}
-      className="group grid grid-cols-[1fr_auto] py-[26px] px-[8px] border-t border-border-card transition-all duration-[180ms] hover:bg-[rgba(138,144,240,0.05)] hover:shadow-card-hover"
-    >
+  const href = `/projects/${slug}`
+  const className =
+    'group grid grid-cols-[1fr_auto] py-[26px] px-[8px] border-t border-border-card transition-all duration-[180ms] hover:bg-[rgba(138,144,240,0.05)] hover:shadow-card-hover'
+
+  const inner = (
+    <>
       <div>
         <DomainTag>{tag}</DomainTag>
         <h3 className="text-card-title font-medium text-text-primary mt-[9px] mb-[8px] transition-colors group-hover:text-accent">
@@ -54,6 +61,27 @@ export default function ProjectCard({
         className="ti ti-arrow-up-right text-text-faint text-[17px] mt-[6px]"
         aria-hidden="true"
       />
-    </Link>
+    </>
+  )
+
+  const reduced = useReducedMotion()
+
+  if (reduced) {
+    return (
+      <Link href={href} className={className}>
+        {inner}
+      </Link>
+    )
+  }
+
+  return (
+    <MotionLink
+      href={href}
+      className={className}
+      whileHover={{ x: 2 }}
+      transition={{ duration: 0.15 }}
+    >
+      {inner}
+    </MotionLink>
   )
 }

--- a/components/organisms/PersonaColumn.tsx
+++ b/components/organisms/PersonaColumn.tsx
@@ -11,7 +11,7 @@ export default function PersonaColumn() {
           React · Next.js · Node · AWS · GCP
         </p>
         <div className="flex items-center gap-[9px] mt-6 font-mono text-mono-sm text-text-dim tracking-[0.03em]">
-          <span className="w-[7px] h-[7px] rounded-full bg-accent shadow-[0_0_11px_rgba(138,144,240,0.85)]" />
+          <span className="w-[7px] h-[7px] rounded-full bg-accent shadow-[0_0_11px_rgba(63, 78, 157, 0.85)]" />
           Available for full-stack roles
         </div>
       </div>

--- a/components/organisms/RightColumnContent.tsx
+++ b/components/organisms/RightColumnContent.tsx
@@ -1,0 +1,86 @@
+'use client'
+
+import Link from 'next/link'
+import { motion, type Variants } from 'framer-motion'
+import { SectionEyebrow } from '@/components/atoms/SectionEyebrow'
+import ProjectCard from '@/components/molecules/ProjectCard'
+import { projects } from '@/data/projects'
+import { useReducedMotion } from '@/hooks/useReducedMotion'
+
+const container: Variants = {
+  hidden: {},
+  show: { transition: { staggerChildren: 0.08 } },
+}
+const item: Variants = {
+  hidden: { opacity: 0, y: 12 },
+  show: { opacity: 1, y: 0, transition: { duration: 0.4, ease: 'easeOut' } },
+}
+
+const mainClassName =
+  'relative pt-4 pb-[72px] lg:py-[72px] px-5 lg:pl-[52px] lg:px-[8px] border-l border-border-subtle lg:pb-[84px]'
+
+// The right column content, split out from app/page.tsx so it can run on the
+// client and stagger its sections in on first paint.
+export default function RightColumnContent() {
+  const reduced = useReducedMotion()
+
+  const about = (
+    <>
+      <SectionEyebrow>About</SectionEyebrow>
+      <p
+        className="text-body text-text-muted leading-[1.85] max-w-[580px] mt-4 mb-[56px]"
+        style={{ textWrap: 'pretty' }}
+      >
+        Full-stack developer in Denver with three years building production
+        software for a telehealth startup, where I grew from entry-level into
+        the lead role. Most of my work lives on the backend and in
+        infrastructure — a custom FHIR-based EHR, serverless APIs, CI/CD,
+        and integrations across Stripe, CRM, and healthcare systems.
+      </p>
+    </>
+  )
+
+  const featured = (
+    <>
+      <SectionEyebrow>Featured Projects</SectionEyebrow>
+      <div className="flex flex-col mt-1 border-b border-border-card">
+        {projects.map((project) => (
+          <ProjectCard key={project.slug} {...project} />
+        ))}
+      </div>
+    </>
+  )
+
+  const more = (
+    <Link
+      href="/projects"
+      className="inline-flex items-center gap-[8px] text-accent font-mono text-mono-md mt-[30px] py-[6px] transition-all hover:gap-[12px]"
+    >
+      <i className="ti ti-arrow-right" aria-hidden="true" />
+      More projects, experiments &amp; home-lab notes
+    </Link>
+  )
+
+  if (reduced) {
+    return (
+      <main className={mainClassName}>
+        {about}
+        {featured}
+        {more}
+      </main>
+    )
+  }
+
+  return (
+    <motion.main
+      className={mainClassName}
+      variants={container}
+      initial="hidden"
+      animate="show"
+    >
+      <motion.div variants={item}>{about}</motion.div>
+      <motion.div variants={item}>{featured}</motion.div>
+      <motion.div variants={item}>{more}</motion.div>
+    </motion.main>
+  )
+}


### PR DESCRIPTION
## Summary
Removes both sources of violet glow from the homepage (orb + nebula haze).
Keeps the Framer Motion additions for card hover and page entry stagger.

## Changes

### Removed — glow orb (components/organisms/PersonaColumn.tsx)
Reverted to HEAD state via `git checkout HEAD -- ...`, stripping out the
uncommitted Framer work: `'use client'`, framer-motion + useReducedMotion
imports, the breathe keyframe, and the two breathing `motion.div` glow orbs.

### Removed — nebula haze (app/layout.tsx)
Removed `NebulaLayer` import and `<NebulaLayer />` from the body.
`NebulaLayer.tsx` left in place — restore two lines to remount later.

Background now renders as: deep-space radial gradient → starfield. No orb, no nebula.

### Kept — Framer Motion (card hover + page entry stagger)
- `components/molecules/ProjectCard.tsx` — `whileHover` lift
- `components/organisms/RightColumnContent.tsx` — new extracted right-column organism
- `app/page.tsx` — renders `<RightColumnContent />`

## Notes
- All motion gated on `useReducedMotion()`
- `NebulaLayer.tsx` intentionally preserved for future use

## Testing
- [ ] No violet glow visible on homepage (orb or nebula)
- [ ] Card hover lift still works
- [ ] Page entry stagger fires on fresh load
- [ ] `npm run build` passes